### PR TITLE
Conda/Travis skeleton.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+
+sudo: false
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+
+install:
+  - source devtools/travis-ci/install.sh
+
+script:
+  - conda build devtools/conda-recipe
+
+env:
+  matrix:
+    - python=2.7  CONDA_PY=27
+    - python=3.4  CONDA_PY=34
+
+  global:
+    # BINSTAR
+    #- secure:
+
+after_success:
+  - source devtools/travis-ci/post_binstar.sh
+

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -1,0 +1,34 @@
+Developer Notes / Tools / License
+=================================
+
+Assorted notes for developers.
+
+Most of these tools were adapted from MDTraj and are released under the following
+ license:
+
+License
+-------
+Copyright (c) 2012-2015 Stanford University and the Authors
+All rights reserved.
+
+Redistribution and use of all files in this folder (devtools) and (../.travis.yml,
+../basesetup.py, ../setup.py) files in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/devtools/conda-recipe/bld.bat
+++ b/devtools/conda-recipe/bld.bat
@@ -1,0 +1,3 @@
+xcopy %RECIPE_DIR%\\..\\.. %SRC_DIR% /e /h /Y /Q
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp -r $RECIPE_DIR/../.. $SRC_DIR
+$PYTHON setup.py clean
+$PYTHON setup.py install

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -2,4 +2,4 @@
 
 cp -r $RECIPE_DIR/../.. $SRC_DIR
 $PYTHON setup.py clean
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: imolecule
+  version: !!str 0.1.9.dev0
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - ipython
+    - tornado
+
+about:
+  home: http://patrick-fuller.com/imolecule/
+  license: MIT
+  summary: An embeddable webGL molecule viewer and file format converter.

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -5,6 +5,7 @@ package:
 requirements:
   build:
     - python
+    - ipython
 
   run:
     - python

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,0 +1,12 @@
+MINICONDA=Miniconda-latest-Linux-x86_64.sh
+MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget http://repo.continuum.io/miniconda/$MINICONDA
+if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+    echo "Miniconda MD5 mismatch"
+    exit 1
+fi
+bash $MINICONDA -b
+
+export PATH=$HOME/miniconda/bin:$PATH
+conda install --yes conda-build jinja2 anaconda-client pip
+

--- a/devtools/travis-ci/post_binstar.sh
+++ b/devtools/travis-ci/post_binstar.sh
@@ -1,0 +1,27 @@
+echo $TRAVIS_PULL_REQUEST $TRAVIS_BRANCH
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    echo "This is a pull request. No deployment will be done."; exit 0
+fi
+
+
+if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
+fi
+
+
+if [[ "2.7 3.4" =~ "$python" ]]; then
+    conda-server -t "$BINSTAR_TOKEN"  upload --force --user patrickfuller --package imolecule $HOME/miniconda/conda-bld/linux-64/imolecule-*
+    conda convert $HOME/miniconda/conda-bld/linux-64/imolecule-* -p all
+    ls
+    conda-server -t "$BINSTAR_TOKEN"  upload --force --user patrickfuller --package imolecule linux-32/imolecule-*
+    conda-server -t "$BINSTAR_TOKEN"  upload --force --user patrickfuller --package imolecule win-32/imolecule-*
+    conda-server -t "$BINSTAR_TOKEN"  upload --force --user patrickfuller --package imolecule win-64/imolecule-*
+    conda-server -t "$BINSTAR_TOKEN"  upload --force --user patrickfuller --package imolecule osx-64/imolecule-*
+fi
+
+if [[ "$python" != "2.7" ]]; then
+    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
+fi
+
+

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
                                        "imolecule/server/*.template"]},
     include_package_data=True,
     packages=["imolecule", "imolecule.server", "imolecule.js"],
-    install_requires=["ipython", "tornado"],
     entry_points={
         "console_scripts": [
             "imolecule = imolecule.server:start_server"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
                                        "imolecule/server/*.template"]},
     include_package_data=True,
     packages=["imolecule", "imolecule.server", "imolecule.js"],
+    install_requires=["ipython", "tornado"],
     entry_points={
         "console_scripts": [
             "imolecule = imolecule.server:start_server"


### PR DESCRIPTION
This is a stripped down version of what we're using right now to build conda packages on Travis. It builds locally for me but will need an encrypted binstar token for Travis and probably some other debugging. 

I've also turned off the setuptools dependency resolution. What's the preferred way to keep this on but disable it during conda builds?