### PR TITLE
Added openbabel >= 3.0.0 support in format_converter

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,6 +1,6 @@
 MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget http://repo.continuum.io/miniconda/$MINICONDA
+wget https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,5 +1,5 @@
 MINICONDA=Miniconda3-latest-Linux-x86_64.sh
-MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget http://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"


### PR DESCRIPTION
OBElementTable is no longer a class in openbabel > 3.0, but a namespace, so it can be accessed directly. I made some adaptations to format_converter to support openbabel > 3.0.